### PR TITLE
Utilize Pre-installed bpftrace Across Other Architectures

### DIFF
--- a/sched-scoreboard.sh
+++ b/sched-scoreboard.sh
@@ -133,6 +133,7 @@ if [ $BPF_NEEDED == 1 ]
 then
     export BPFTRACE_MAP_KEYS_MAX=$MAX_PIDS
 
+    command -v bpftrace >/dev/null 2>&1 && ln -s $(which bpftrace) bpftrace
     if [ ! -f $SCRIPTDIR/bpftrace ]
     then
 	    echo "Downloading bpftrace v0.16.0...."


### PR DESCRIPTION
This commit enhances the script's usability by enabling it to use an existing bpftrace installation, thus supporting various architectures where bpftrace is already installed. It creates a symbolic link to the installed bpftrace, avoiding unnecessary downloads. If bpftrace is not found, the script will continue to download it as before. This change streamlines the setup process and broadens script applicability. Future enhancements will aim at increasing adaptability across different system configurations.