### PR TITLE
Check sched_verbose flag before accessing domain files

### DIFF
--- a/sched-scoreboard.sh
+++ b/sched-scoreboard.sh
@@ -107,6 +107,10 @@ SCRIPTDIR=`dirname "$0"`;
 
 mkdir -p $LOGDIR
 
+if ! grep -Fxq "Y" /sys/kernel/debug/sched/verbose; then
+    echo 'Y' >/sys/kernel/debug/sched/verbose
+fi
+
 if [ -d /sys/kernel/debug/sched/domains/cpu0 ]
 then
     grep . /sys/kernel/debug/sched/domains/cpu0/domain*/name | sed -e 's/\/sys\/kernel\/debug\/sched\/domains\/cpu0\///g' | sed -e 's/\/name//g' > $LOGDIR/domain_map.cfg


### PR DESCRIPTION
The changes in this commit enables verbose for the kernel scheduler by checking the current status of verbose logging from `/sys/kernel/debug/sched/verbose`. If it's not already enabled, the script will enable it by echoing 'Y' into the aforementioned path. 

Domain files are not created by default in the latest upstream kernels. Having this check would ensure it's enabled before we access domainl files under the directory /sys/kernel/debug/sched/domains/*

Link: https://lore.kernel.org/all/20230303183754.3076321-1-pauld@redhat.com/