### PR TITLE
capture_taskstats: Iterate over /proc/pid/task/tid

### DIFF
--- a/capture_taskstat.py
+++ b/capture_taskstat.py
@@ -7,7 +7,16 @@ import shutil
 tasks = os.listdir("/proc")
 
 for task in tasks:
-    if task.isdigit():
-        source = os.path.join("/proc", task, "sched")
-        dest = os.path.join(sys.argv[1], task)
+    if not task.isdigit():
+        continue
+
+    task_dir = os.path.join("/proc", task)
+    thread_dir = os.path.join(task_dir, "task")
+    threads = os.listdir(thread_dir)
+    for thread in threads:
+        if not thread.isdigit():
+            continue
+
+        source = os.path.join(thread_dir, thread, "sched")
+        dest = os.path.join(sys.argv[1], thread)
         shutil.copyfile(source, dest)

--- a/sched-scoreboard.sh
+++ b/sched-scoreboard.sh
@@ -107,9 +107,8 @@ SCRIPTDIR=`dirname "$0"`;
 
 mkdir -p $LOGDIR
 
-if ! grep -Fxq "Y" /sys/kernel/debug/sched/verbose; then
-    echo 'Y' >/sys/kernel/debug/sched/verbose
-fi
+old_sched_verbose=`cat /sys/kernel/debug/sched/verbose`
+echo 'Y' > /sys/kernel/debug/sched/verbose
 
 if [ -d /sys/kernel/debug/sched/domains/cpu0 ]
 then
@@ -118,6 +117,8 @@ elif [ -d /proc/sys/kernel/sched_domain/cpu0 ]
 then
     grep . /proc/sys/kernel/sched_domain/cpu0/domain*/name | sed -e 's/\/proc\/sys\/kernel\/sched_domain\/cpu0\///g' | sed -e 's/\/name//g' > $LOGDIR/domain_map.cfg
 fi
+
+echo $old_sched_verbose > /sys/kernel/debug/sched/verbose
 
 TIMESTAMP=`date +%Y-%m-%d\ %H:%M:%S`
 echo "[$TIMESTAMP] Snapshotting schedstats before..."


### PR DESCRIPTION
os.listdir("/proc") would not iterate over the threads of a process. Hence, ensure that we peek into /proc/pid/task/tid which would lists all the threads of that process and copy the /proc/pid/task/tid/sched for each thread.

Reported-by: Alexey Kardashevskiy <aik@ozlabs.ru>