### PR TITLE
Fixing config.gz file management and enchaning $SCRIPTDIR resolution

### DIFF
--- a/sched-scoreboard.sh
+++ b/sched-scoreboard.sh
@@ -103,7 +103,7 @@ else
     echo "command to be executed : $command"
 fi
 
-SCRIPTDIR=`dirname "$0"`;
+SCRIPTDIR=`dirname $(realpath "$0")`;
 
 mkdir -p $LOGDIR
 
@@ -154,10 +154,7 @@ then
         CONFIG_FILE=""
         if [ -f /proc/config.gz ]
         then
-            cp /proc/config.gz $LOGDIR
-            cd $LOGDIR
-            gunzip config.gz
-            mv -f config config-$VERSION
+            gunzip -c /proc/config.gz > $LOGDIR/config-$VERSION
             CONFIG_FILE=$LOGDIR/config-$VERSION
             ORIG_CONFIG_FILE="/proc/config.gz"
         elif [ -f /boot/config-$VERSION ]


### PR DESCRIPTION
Refactored sched-scoreboard.sh to improve efficiency and prevent errors. Replaced the process of changing into $LOGDIR with a direct `gunzip -c` command to avoid errors caused by directory changes. Enhanced SCRIPTDIR resolution to use the script's absolute path, ensuring robust and error-free path handling across different execution contexts.